### PR TITLE
fix subsystem dependency resolution (v0.4.0)

### DIFF
--- a/area51.asd
+++ b/area51.asd
@@ -1,5 +1,5 @@
 (defsystem "area51"
-  :version "0.1.0"
+  :version "0.4.0"
   :author ""
   :license "MIT"
   :description "Common Lisp Package Manager"

--- a/src/core/resolver.lisp
+++ b/src/core/resolver.lisp
@@ -12,6 +12,17 @@
 (defun package-cache-dir (name)
   (merge-pathnames (format nil "~a/" name) *packages-dir*))
 
+;;; --- Helpers ---
+
+(defun subsystem-p (name)
+  "Check if NAME is a subsystem (contains \"/\")."
+  (position #\/ name))
+
+(defun base-system-name (name)
+  "Extract base system name: \"foo/bar/baz\" → \"foo\"."
+  (let ((slash (position #\/ name)))
+    (if slash (subseq name 0 slash) name)))
+
 ;;; --- .asd parsing ---
 
 (defun find-asd-files (dir)
@@ -20,28 +31,35 @@
     (directory pattern)))
 
 (defun parse-asd-depends (asd-path)
-  "Extract :depends-on list from a .asd file."
+  "Extract :depends-on from ALL defsystem forms in a .asd file.
+Subsystem names (containing /) are converted to their base system name."
   (handler-case
-      (with-open-file (in asd-path :direction :input)
-        (let ((*read-eval* nil)
-              (*package* (find-package :cl-user)))
-          (loop for form = (read in nil :eof)
-                until (eq form :eof)
-                when (and (listp form)
-                          (symbolp (car form))
-                          (string-equal (symbol-name (car form)) "DEFSYSTEM"))
-                  do (let ((plist (cddr form)))
-                       (loop for (key val) on plist by #'cddr
-                             when (and (symbolp key)
-                                       (string-equal (symbol-name key)
-                                                     "DEPENDS-ON"))
-                               do (return-from parse-asd-depends
-                                    (mapcar (lambda (d)
-                                              (string-downcase
-                                               (if (symbolp d)
-                                                   (symbol-name d)
-                                                   (princ-to-string d))))
-                                            val)))))))
+      (let ((all-deps nil))
+        (with-open-file (in asd-path :direction :input)
+          (let ((*read-eval* nil)
+                (*package* (find-package :cl-user)))
+            (loop for form = (read in nil :eof)
+                  until (eq form :eof)
+                  when (and (listp form)
+                            (symbolp (car form))
+                            (string-equal (symbol-name (car form)) "DEFSYSTEM"))
+                    do (let ((plist (cddr form)))
+                         (loop for (key val) on plist by #'cddr
+                               when (and (symbolp key)
+                                         (string-equal (symbol-name key)
+                                                       "DEPENDS-ON"))
+                                 do (dolist (d val)
+                                      (let ((name (string-downcase
+                                                   (if (symbolp d)
+                                                       (symbol-name d)
+                                                       (princ-to-string d)))))
+                                        ;; For subsystems (foo/bar), add the base name (foo)
+                                        (let ((resolved-name (if (subsystem-p name)
+                                                                 (base-system-name name)
+                                                                 name)))
+                                          (pushnew resolved-name all-deps
+                                                   :test #'string=)))))))))
+        (nreverse all-deps))
     (error () nil)))
 
 (defun builtin-system-p (name)
@@ -51,11 +69,17 @@
 
 (defun find-system-in-cache (name)
   "Search for a system in cached packages by scanning .asd files."
-  (let ((packages-dir (namestring *packages-dir*)))
+  (let ((packages-dir (namestring *packages-dir*))
+        (base-name (base-system-name name)))
     (when (probe-file packages-dir)
       (dolist (pkg-dir (directory (merge-pathnames "*/" packages-dir)))
         (dolist (asd (find-asd-files pkg-dir))
+          ;; Direct match by filename
           (when (string-equal name (pathname-name asd))
+            (return-from find-system-in-cache pkg-dir))
+          ;; Subsystem: match by base name
+          (when (and (not (string= name base-name))
+                     (string-equal base-name (pathname-name asd)))
             (return-from find-system-in-cache pkg-dir)))))))
 
 ;;; --- Dependency resolution ---
@@ -83,25 +107,30 @@
               (format t "  ~a <- ~a~%" name url)
               (git-clone url (namestring cache-dir) :ref ref)
               cache-dir))
-        ;; Quicklisp source
+        ;; Quicklisp source — check direct cache first, then scan
         (if (probe-file cache-dir)
             (progn
               (format t "  ~a (cached)~%" name)
               cache-dir)
-            (progn
-              (format t "  ~a <- quicklisp~%" name)
-              (let ((path (download-quicklisp-package name)))
-                (or path
-                    (progn
-                      (format *error-output*
-                              "  ~a not found in Quicklisp index~%" name)
-                      nil))))))))
+            (let ((cached (find-system-in-cache name)))
+              (if cached
+                  (progn
+                    (format t "  ~a (cached)~%" name)
+                    cached)
+                  (progn
+                    (format t "  ~a <- quicklisp~%" name)
+                    (let ((path (download-quicklisp-package name)))
+                      (or path
+                          (progn
+                            (format *error-output*
+                                    "  ~a not found in Quicklisp index~%" name)
+                            nil))))))))))
 
 (defun resolve-all (config)
   "Resolve all dependencies recursively.
    1. Resolve direct dependencies from area51.lisp
    2. Parse each package's .asd for :depends-on
-   3. Recursively resolve transitive dependencies (fallback to Quicklisp)
+   3. Recursively resolve transitive dependencies
    4. Report unresolved dependencies"
   (let ((deps (config-dependencies config))
         (resolved (make-hash-table :test 'equal))
@@ -127,26 +156,14 @@
                               :source (if (dep-is-github-p dep) :github :quicklisp)
                               :sha (ignore-errors
                                      (git-rev-parse (namestring path)))))
-                  ;; Find transitive dependencies
+                  ;; Find transitive dependencies — always queue them
+                  ;; so their own transitive deps get scanned too
                   (dolist (asd (find-asd-files path))
                     (let ((transitive-deps (parse-asd-depends asd)))
                       (dolist (td transitive-deps)
                         (unless (or (gethash td resolved)
                                     (builtin-system-p td))
-                          ;; Check if it exists in cache
-                          (let ((cached-path (find-system-in-cache td)))
-                            (if cached-path
-                                ;; Found in cache
-                                (setf (gethash td resolved)
-                                      (list :name td
-                                            :path (namestring cached-path)
-                                            :source :cached
-                                            :sha (ignore-errors
-                                                   (git-rev-parse
-                                                    (namestring cached-path)))))
-                                ;; Not in cache — queue for Quicklisp fallback
-                                (push (list :name td)
-                                      queue))))))))
+                          (push (list :name td) queue))))))
                 ;; Failed to resolve
                 (pushnew name unresolved :test #'string=))))))
     ;; Report unresolved

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package #:area51)
 
-(defparameter *version* "0.3.5")
+(defparameter *version* "0.4.0")
 
 (defun print-version ()
   (format t "area51 ~a~%" *version*))


### PR DESCRIPTION
## Summary
- **parse-asd-depends**: extract `:depends-on` from ALL `defsystem` forms, not just the first one. Subsystem names (`foo/bar`) are converted to base name (`foo`).
- **find-system-in-cache**: support subsystem lookup by matching base system name against .asd filenames.
- **resolve-dep**: check direct cache first, fall back to `find-system-in-cache` for packages where Quicklisp name differs from system name (e.g. `cl-frugal-uuid` vs `frugal-uuid`).
- **resolve-all**: always queue transitive dependencies for full recursive resolution, fixing cache-hit short-circuit that skipped deeper deps.

## Problem
Packages depending on ASDF subsystems (e.g. `cl-smtp` → `frugal-uuid/non-frugal` → `trivial-clock`) failed to resolve because:
1. Only the first `defsystem` in a `.asd` file was parsed
2. Cached packages had their transitive dependencies skipped
3. Subsystem names couldn't be matched to their parent `.asd` files

## Test plan
- [ ] `area51 install` resolves `cl-smtp` and all transitive deps including `trivial-clock`
- [ ] `area51 build` succeeds for projects depending on `cl-smtp`
- [ ] No performance regression on install (direct cache check before full scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)