### PR TITLE
Fix transitive dep loss from .asd files using #. forms

### DIFF
--- a/src/core/resolver.lisp
+++ b/src/core/resolver.lisp
@@ -30,13 +30,28 @@
   (let ((pattern (merge-pathnames "*.asd" dir)))
     (directory pattern)))
 
+(defun skip-sharp-dot-reader (stream subchar arg)
+  "Custom reader for #. that reads the following form as data and discards it.
+Used to parse .asd files safely without evaluating #. forms (e.g. :long-description
+that reads README at load time)."
+  (declare (ignore subchar arg))
+  (let ((*read-suppress* t))
+    (read stream t nil t))
+  nil)
+
+(defun make-asd-readtable ()
+  "Readtable for parsing .asd files: #. forms are skipped instead of evaluated."
+  (let ((rt (copy-readtable nil)))
+    (set-dispatch-macro-character #\# #\. #'skip-sharp-dot-reader rt)
+    rt))
+
 (defun parse-asd-depends (asd-path)
   "Extract :depends-on from ALL defsystem forms in a .asd file.
 Subsystem names (containing /) are converted to their base system name."
   (handler-case
       (let ((all-deps nil))
         (with-open-file (in asd-path :direction :input)
-          (let ((*read-eval* nil)
+          (let ((*readtable* (make-asd-readtable))
                 (*package* (find-package :cl-user)))
             (loop for form = (read in nil :eof)
                   until (eq form :eof)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package #:area51)
 
-(defparameter *version* "0.4.1")
+(defparameter *version* "0.4.2")
 
 (defun print-version ()
   (format t "area51 ~a~%" *version*))


### PR DESCRIPTION
`parse-asd-depends` read .asd files with *read-eval* nil, which causes a reader error on any `#.` form. The error was caught by a top-level handler-case and swallowed, returning nil — so ALL deps of packages with `#.` (like fast-http with `:long-description #.(with-open-file ...)`) were silently dropped.

Real-world impact: fast-http's proc-parse and xsubseq never got installed, breaking any project that transitively depends on woo.

Fix by installing a custom readtable that treats `#.` as a skip (reads the following form with *read-suppress* t and returns nil). This preserves the safety of not evaluating .asd contents at parse time while allowing files with read-time-eval forms to parse cleanly.