### PR TITLE
Recursively discover .asd files in nested subdirectories

### DIFF
--- a/src/core/lisp-impl.lisp
+++ b/src/core/lisp-impl.lisp
@@ -18,9 +18,11 @@
 
 (defun asdf-setup-form ()
   "Generate a form that configures ASDF to find this project's locked dependencies.
-   Uses per-package :directory entries from area51.lock for true per-project
-   isolation. Falls back to a :tree over the global packages dir when no lock
-   file is available (e.g. during install)."
+   Uses per-package :tree entries from area51.lock for true per-project
+   isolation. :tree (not :directory) is used because some packages ship
+   with sub-systems in subdirectories (e.g. mgl-pax/autoload/autoload.asd).
+   Falls back to a :tree over the global packages dir when no lock file
+   is available (e.g. during install)."
   (let ((paths (package-paths-from-lock)))
     (if paths
         (with-output-to-string (out)
@@ -28,7 +30,7 @@
            "(asdf:initialize-source-registry (list :source-registry "
            out)
           (dolist (p paths)
-            (format out "(list :directory ~s) " p))
+            (format out "(list :tree ~s) " p))
           (write-string ":inherit-configuration))" out))
         (format nil "(asdf:initialize-source-registry ~
                      (list :source-registry ~

--- a/src/core/resolver.lisp
+++ b/src/core/resolver.lisp
@@ -26,8 +26,9 @@
 ;;; --- .asd parsing ---
 
 (defun find-asd-files (dir)
-  "Find all .asd files in a directory (non-recursive)."
-  (let ((pattern (merge-pathnames "*.asd" dir)))
+  "Find all .asd files in a directory tree (recursive).
+Some packages (e.g. mgl-pax) ship with sub-systems in subdirectories."
+  (let ((pattern (merge-pathnames "**/*.asd" dir)))
     (directory pattern)))
 
 (defun skip-sharp-dot-reader (stream subchar arg)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package #:area51)
 
-(defparameter *version* "0.4.2")
+(defparameter *version* "0.4.3")
 
 (defun print-version ()
   (format t "area51 ~a~%" *version*))


### PR DESCRIPTION
Some Quicklisp packages ship with sub-systems in subdirectories — e.g. mgl-pax contains autoload/autoload.asd and dref/dref.asd. These were invisible to both:

  - parse-asd-depends (via find-asd-files): transitive deps of sub-systems never got queued for resolution.
  - ASDF at load time: :directory in the source-registry only sees top-level .asd files, so loading mgl-pax-bootstrap failed with 'Component "autoload" not found'.

Fix both sites:

  - find-asd-files now recurses with **/*.asd
  - asdf-setup-form uses :tree per package path (not :directory), so ASDF recursively finds nested .asd files during load.